### PR TITLE
Refactor/signup flow

### DIFF
--- a/oauth.go
+++ b/oauth.go
@@ -429,5 +429,9 @@ func (svc *AlbyOAuthService) CallbackHandler(c echo.Context) error {
 	}
 	sess.Values["user_id"] = user.ID
 	sess.Save(c.Request(), c.Response())
+	appName := sess.Values["app_name"].(string)
+	if appName != "" {
+		return c.Redirect(302, fmt.Sprintf("/apps/new?c=%s", appName))
+	}
 	return c.Redirect(302, "/apps")
 }

--- a/oauth.go
+++ b/oauth.go
@@ -206,10 +206,8 @@ func (svc *AlbyOAuthService) SendPaymentSync(ctx context.Context, senderPubkey, 
 func (svc *AlbyOAuthService) IndexHandler(c echo.Context) error {
 	appName := c.QueryParam("c") // c - for client
 	sess, _ := session.Get("alby_nostr_wallet_connect", c)
-	if appName != "" {
-		sess.Values["app_name"] = appName
-		sess.Save(c.Request(), c.Response())
-	}
+	sess.Values["app_name"] = appName
+	sess.Save(c.Request(), c.Response())
 	userID := sess.Values["user_id"]
 	if userID != nil {
 		if appName != "" {

--- a/views/apps/create_mobile.html
+++ b/views/apps/create_mobile.html
@@ -1,0 +1,27 @@
+{{define "body"}}
+<a class="mb-6 block" href="/apps">
+  <i class="fas fa-arrow-left" aria-hidden="true"></i>
+  All sessions
+</a>
+
+<div class="bg-green-100 border-t-4 border-green-500 rounded-b px-4 py-3 shadow-md mb-8" role="alert">
+  <div class="flex">
+    <div class="py-1"><svg class="fill-current h-6 w-6 mr-4" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20">
+        <path
+          d="M2.93 17.07A10 10 0 1 1 17.07 2.93 10 10 0 0 1 2.93 17.07zm12.73-1.41A8 8 0 1 0 4.34 4.34a8 8 0 0 0 11.32 11.32zM9 11V9h2v6H9v-4zm0-6h2v2H9V5z">
+        </path>
+      </svg></div>
+    <div>
+      <p class="font-bold">Session created</p>
+      <p class="text-sm">The application session was successfully created. Please connect your app now</p>
+    </div>
+  </div>
+</div>
+
+<a class=" inline-flex bg-white border border-warmGray cursor-pointer dark:bg-surface-02dp dark:border-neutral-800 dark:hover:bg-surface-16dp dark:text-neutral-200 duration-150 focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-orange-bitcoin focus:outline-none font-medium hover:bg-gray-50 items-center justify-center px-5 py-3 rounded-md shadow text-gray-700 transition "
+    href="{{.PairingUri}}">
+    <i class="fas fa-key mr-3" aria-hidden="true"></i>
+    Connect & back to application
+</a>
+
+{{end}}

--- a/views/apps/new.html
+++ b/views/apps/new.html
@@ -29,21 +29,6 @@
     </ul>
   </div>
 
-  <div class="mb-4">
-    <a href="#" class="underline mb-4"
-      onclick="document.getElementById('advanced-settings').classList.toggle('hidden');return false">Advanced
-      settings</a>
-    <div id="advanced-settings" class="hidden">
-      <label for="pubkey" class="block mb-2 text-sm font-medium text-gray-900 dark:text-white">Public key</label>
-      <input type="pubkey" name="pubkey" id="pubkey" aria-describedby="helper-text-explanation"
-        class="bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5  dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500"
-        placeholder="npub..." pattern="npub.*">
-      <p id="helper-text-explanation" class="mt-2 text-sm text-gray-500 dark:text-gray-400">
-        Manually configure the public pairing key for this session.
-      </p>
-    </div>
-  </div>
-
   <button type="submit"
     class="inline-flex bg-white border border-warmGray cursor-pointer dark:bg-surface-02dp dark:border-neutral-800 dark:hover:bg-surface-16dp dark:text-neutral-200 duration-150 focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-orange-bitcoin focus:outline-none font-medium hover:bg-gray-50 items-center justify-center px-5 py-3 rounded-md shadow text-gray-700 transition ">
     Save


### PR DESCRIPTION
Fixes #22 

The following changes have been made to the redirection flow:

- If a user lands on `/` and has a session cookie (they are already logged in), redirect to the `/apps` dashboard instead of showing the login page.
- If a user lands on `/` and the client Query parameter `c=someApp` is set, redirect to `apps/new?c=someApp`. If the user is not logged in, add `app_name=someApp` to the session before starting the OAuth flow.
- If the user is redirected back from the OAuth flow, check the session for `app_name=someApp`. If it is set, also redirect the user to `apps/new?c=someApp`.
- Remove the option for a user to set their own pubkey when connecting, it is not necessary.
- When the user finally lands on `apps/new` with the query parameter `c=someApp`, **automatically create the client**. There is no need to ask for confirmation again. If they didn't want to create it they can just go back and delete it again.
- On mobile, don't show the QR code but only show a button with the deeplink to go back to the client (Amethyst).

So to summarize, if you just go to `https://nwc.getalby.com` on desktop everything will be mostly the same, but the flow on mobile is heavily simplified if `c=someApp` is set.

![Screenshot_2023-04-04-15-10-52-10_3aea4af51f236e4932235fdada7d1643](https://user-images.githubusercontent.com/33457577/229804629-041d01e3-1114-47a0-b5b5-f424de8c3dd5.jpg)
