### PR TITLE
allow only single concurrent connection for SQLite to prevent lock-up

### DIFF
--- a/main.go
+++ b/main.go
@@ -45,6 +45,8 @@ func main() {
 		if err != nil {
 			log.Fatalf("Failed to open DB %v", err)
 		}
+		// Override SQLite config to max one connection
+		cfg.DatabaseMaxConns = 1
 	}
 	sqlDb, err := db.DB()
 	if err != nil {


### PR DESCRIPTION
This should fix #76, but I haven't tested it yet. If someone would like to review or test, please. Thank you.