### PR TITLE
fix: rename cookie and make it domain level

### DIFF
--- a/echo_handlers.go
+++ b/echo_handlers.go
@@ -81,7 +81,7 @@ func (svc *Service) RegisterSharedRoutes(e *echo.Echo) {
 }
 
 func (svc *Service) IndexHandler(c echo.Context) error {
-	sess, _ := session.Get("alby_nostr_wallet_connect", c)
+	sess, _ := session.Get("nwc_session", c)
 	returnTo := sess.Values["return_to"]
 	user, err := svc.GetUser(c)
 	if err != nil {
@@ -219,7 +219,7 @@ func (svc *Service) AppsNewHandler(c echo.Context) error {
 		return err
 	}
 	if user == nil {
-		sess, _ := session.Get("alby_nostr_wallet_connect", c)
+		sess, _ := session.Get("nwc_session", c)
 		sess.Values["return_to"] = c.Path() + "?" + c.QueryString()
 		sess.Save(c.Request(), c.Response())
 		return c.Redirect(302, fmt.Sprintf("/%s/auth", strings.ToLower(svc.cfg.LNBackendType)))
@@ -346,9 +346,10 @@ func (svc *Service) AppsDeleteHandler(c echo.Context) error {
 }
 
 func (svc *Service) LogoutHandler(c echo.Context) error {
-	sess, _ := session.Get("alby_nostr_wallet_connect", c)
-	sess.Options = &sessions.Options{
-		MaxAge: -1,
+	sess, _ := session.Get("nwc_session", c)
+	sess.Options.MaxAge = -1
+	if svc.cfg.CookieDomain != "" {
+		sess.Options.Domain = svc.cfg.CookieDomain
 	}
 	sess.Save(c.Request(), c.Response())
 	return c.Redirect(302, "/")

--- a/lnd.go
+++ b/lnd.go
@@ -32,7 +32,7 @@ func (svc *LNDService) AuthHandler(c echo.Context) error {
 		return err
 	}
 
-	sess, _ := session.Get("alby_nostr_wallet_connect", c)
+	sess, _ := session.Get("nwc_session", c)
 	sess.Values["user_id"] = user.ID
 	sess.Save(c.Request(), c.Response())
 	return c.Redirect(302, "/")

--- a/service.go
+++ b/service.go
@@ -25,7 +25,7 @@ type Service struct {
 }
 
 func (svc *Service) GetUser(c echo.Context) (user *User, err error) {
-	sess, _ := session.Get("alby_nostr_wallet_connect", c)
+	sess, _ := session.Get("nwc_session", c)
 	userID := sess.Values["user_id"]
 	if svc.cfg.LNBackendType == LNDBackendType {
 		//if we self-host, there is always only one user


### PR DESCRIPTION
## :warning: Deploying this change will logout all users

Fixes the cookie issue, which is stopping logins and logouts

## Description

The issue is that the `alby_nostr_wallet_connect` cookie was saved in users' browsers under the [nwc.getalby.com](http://nwc.getalby.com/) subdomain, and currently we add the alby_nostr_wallet_connect cookie under [.getalby.com](http://getalby.com/) domain (and in other places, we don't specify the domain cause it does key value matching and we don't know if we get the cookie with subdomain or main domain). So instead of clearing it @bumi said it's better to rename the cookie.

(apart from the [issue](https://getalby.slack.com/archives/C04FDDHNTJ6/p1687938457797709) Moritz mentioned in slack, you can't also log out if you're logged in already, that's because the cookie which is being cleared is of the subdomain and the main domain cookie is never being touched so when it fetches to log you in, this time it gets the main domain cookie (because, key value matching) and shows you the page, but the same thing (k-v matching) isn't applicable for delete as you have to explicitly mention if you need to delete a domain level cookie)