### PR TITLE
feat: allow passing expires_at as a timestamp in seconds

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ If the client creates the secret the client only needs to share the public key o
 - `c`: the name of the client app
 - `pubkey`: the public key of the client's secret for the user to authorize
 - `return_to`: (optional) if a `return_to` URL is provided the user will be redirected to that URL after authorization. The `lud16`, `relay` and `pubkey` query parameters will be added to the URL.
-- `expires_at` (optional) connection cannot be used after this date. Either a UTC date in ISO Format (2023-06-29T13:25:09.582Z), or a unix timestamp
+- `expires_at` (optional) connection cannot be used after this date. Unix timestamp in seconds.
 - `max_amount` (optional) maximum amount in sats that can be sent per renewal period
 - `budget_renewal` (optional) reset the budget at the end of the given budget renewal. Can be `never` (default), `daily`, `weekly`, `monthly`, `yearly`
 - `editable` (optional) set to `false` to disable form editing by the user

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ If the client creates the secret the client only needs to share the public key o
 - `c`: the name of the client app
 - `pubkey`: the public key of the client's secret for the user to authorize
 - `return_to`: (optional) if a `return_to` URL is provided the user will be redirected to that URL after authorization. The `lud16`, `relay` and `pubkey` query parameters will be added to the URL.
-- `expires_at` (optional) connection cannot be used after this date. Format: 2024-05-23
+- `expires_at` (optional) connection cannot be used after this date. Either a UTC date in ISO Format (2023-06-29T13:25:09.582Z), or a unix timestamp
 - `max_amount` (optional) maximum amount in sats that can be sent per renewal period
 - `budget_renewal` (optional) reset the budget at the end of the given budget renewal. Can be `never` (default), `daily`, `weekly`, `monthly`, `yearly`
 - `editable` (optional) set to `false` to disable form editing by the user

--- a/echo_handlers.go
+++ b/echo_handlers.go
@@ -214,7 +214,10 @@ func (svc *Service) AppsNewHandler(c echo.Context) error {
 	returnTo := c.QueryParam("return_to")
 	maxAmount := c.QueryParam("max_amount")
 	budgetRenewal := strings.ToLower(c.QueryParam("budget_renewal"))
-	expiresAt := c.QueryParam("expires_at") // YYYY-MM-DD or MM/DD/YYYY
+	expiresAt := c.QueryParam("expires_at") // YYYY-MM-DD or MM/DD/YYYY or timestamp in seconds
+	if expiresAtTimestamp, err := strconv.Atoi(expiresAt); err == nil {
+    expiresAt = time.Unix(int64(expiresAtTimestamp), 0).Format("2006-01-02")
+	}
 	disabled := c.QueryParam("editable") == "false"
 	budgetEnabled := maxAmount != "" || budgetRenewal != ""
 

--- a/echo_handlers.go
+++ b/echo_handlers.go
@@ -216,7 +216,7 @@ func (svc *Service) AppsNewHandler(c echo.Context) error {
 	budgetRenewal := strings.ToLower(c.QueryParam("budget_renewal"))
 	expiresAt := c.QueryParam("expires_at") // YYYY-MM-DD or MM/DD/YYYY or timestamp in seconds
 	if expiresAtTimestamp, err := strconv.Atoi(expiresAt); err == nil {
-    expiresAt = time.Unix(int64(expiresAtTimestamp), 0).Format("2006-01-02")
+    expiresAt = time.Unix(int64(expiresAtTimestamp), 0).Format(time.RFC3339)
 	}
 	disabled := c.QueryParam("editable") == "false"
 	budgetEnabled := maxAmount != "" || budgetRenewal != ""
@@ -276,7 +276,7 @@ func (svc *Service) AppsCreateHandler(c echo.Context) error {
 	app := App{Name: name, NostrPubkey: pairingPublicKey}
 	maxAmount, _ := strconv.Atoi(c.FormValue("MaxAmount"))
 	budgetRenewal := c.FormValue("BudgetRenewal")
-	expiresAt, _ := time.Parse("2006-01-02", c.FormValue("ExpiresAt"))
+	expiresAt, _ := time.Parse(time.RFC3339, c.FormValue("ExpiresAt"))
 	if !expiresAt.IsZero() {
 		expiresAt = time.Date(expiresAt.Year(), expiresAt.Month(), expiresAt.Day(), 23, 59, 59, 0, expiresAt.Location())
 	}


### PR DESCRIPTION
Note: I decided to still support passing as a date string. This introduces complexity a little but I think it is nice to support both formats. Removing the other would be a breaking change (most likely no-one is using it yet?)