### PR TITLE
add foreign key cascade for sqlite

### DIFF
--- a/main.go
+++ b/main.go
@@ -47,6 +47,8 @@ func main() {
 		}
 		// Override SQLite config to max one connection
 		cfg.DatabaseMaxConns = 1
+		// Enable foreign keys for sqlite
+		db.Exec("PRAGMA foreign_keys=ON;")
 	}
 	sqlDb, err := db.DB()
 	if err != nil {


### PR DESCRIPTION
Fixes #108 
When using sqlite, you need this statement in order to enable foreign key relations and cascade deletes.