### PR TITLE
fix: parse layout

### DIFF
--- a/echo_handlers.go
+++ b/echo_handlers.go
@@ -291,7 +291,7 @@ func (svc *Service) AppsCreateHandler(c echo.Context) error {
 	app := App{Name: name, NostrPubkey: pairingPublicKey}
 	maxAmount, _ := strconv.Atoi(c.FormValue("MaxAmount"))
 	budgetRenewal := c.FormValue("BudgetRenewal")
-	expiresAt, _ := time.Parse(time.RFC3339, c.FormValue("ExpiresAt"))
+	expiresAt, _ := time.Parse("2006-01-02", c.FormValue("ExpiresAt"))
 	if !expiresAt.IsZero() {
 		expiresAt = time.Date(expiresAt.Year(), expiresAt.Month(), expiresAt.Day(), 23, 59, 59, 0, expiresAt.Location())
 	}


### PR DESCRIPTION
Currently `expiryAt` is not parsed properly and is being set as zero everytime, this fixes the layout to parse it correctly