### PR TITLE
Fix/cleanup create app screen

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Example:
 #### Client created secret
 If the client creates the secret the client only needs to share the public key of that secret for authorization. The user authorized that pubkey and no sensitivate data needs to be shared.
 
-##### Query parameter options
+##### Query parameter options for /new
 - `c`: the name of the client app
 - `pubkey`: the public key of the client's secret for the user to authorize
 - `return_to`: (optional) if a `return_to` URL is provided the user will be redirected to that URL after authorization. The `lud16`, `relay` and `pubkey` query parameters will be added to the URL.
@@ -79,6 +79,7 @@ If the client creates the secret the client only needs to share the public key o
 - `max_amount` (optional) maximum amount in sats that can be sent per renewal period
 - `budget_renewal` (optional) reset the budget at the end of the given budget renewal. Can be `never` (default), `daily`, `weekly`, `monthly`, `yearly`
 - `editable` (optional) set to `false` to disable form editing by the user
+- `request_methods` (optional) url encoded, space seperated list of request types that you need permission for: `pay_invoice` (default), `get_balance`  (see NIP47)
 
 Example:
 

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ If the client creates the secret the client only needs to share the public key o
 - `max_amount` (optional) maximum amount in sats that can be sent per renewal period
 - `budget_renewal` (optional) reset the budget at the end of the given budget renewal. Can be `never` (default), `daily`, `weekly`, `monthly`, `yearly`
 - `editable` (optional) set to `false` to disable form editing by the user
-- `request_methods` (optional) url encoded, space seperated list of request types that you need permission for: `pay_invoice` (default), `get_balance`  (see NIP47)
+- `request_methods` (optional) url encoded, space seperated list of request types that you need permission for: `pay_invoice` (default), `get_balance`  (see NIP47). For example: `..&request_methods=pay_invoice%20get_balance`
 
 Example:
 

--- a/echo_handlers.go
+++ b/echo_handlers.go
@@ -237,7 +237,7 @@ func (svc *Service) AppsNewHandler(c echo.Context) error {
 	disabled := c.QueryParam("editable") == "false"
 	requestMethods := c.QueryParam("request_methods")
 	if requestMethods == "" {
-		//default
+		//pay_invoice checkbox is default checked but can be disabled
 		requestMethods = NIP_47_PAY_INVOICE_METHOD
 	}
 	budgetEnabled := maxAmount != "" || budgetRenewal != ""

--- a/echo_handlers.go
+++ b/echo_handlers.go
@@ -190,16 +190,16 @@ func (svc *Service) AppsShowHandler(c echo.Context) error {
 	}
 
 	return c.Render(http.StatusOK, "apps/show.html", map[string]interface{}{
-		"App":            app,
-		"AppPermission":  paySpecificPermission,
-		"RequestMethods": requestMethods,
-		"ExpiresAt":      expiresAt,
-		"User":           user,
-		"LastEvent":      lastEvent,
-		"EventsCount":    eventsCount,
-		"BudgetUsage":    budgetUsage,
-		"RenewsIn":       renewsIn,
-		"Csrf":           csrf,
+		"App":                   app,
+		"PaySpecificPermission": paySpecificPermission,
+		"RequestMethods":        requestMethods,
+		"ExpiresAt":             expiresAt,
+		"User":                  user,
+		"LastEvent":             lastEvent,
+		"EventsCount":           eventsCount,
+		"BudgetUsage":           budgetUsage,
+		"RenewsIn":              renewsIn,
+		"Csrf":                  csrf,
 	})
 }
 

--- a/echo_handlers.go
+++ b/echo_handlers.go
@@ -168,14 +168,12 @@ func (svc *Service) AppsShowHandler(c echo.Context) error {
 	svc.db.Where("app_id = ?", app.ID).Find(&appPermissions)
 
 	requestMethods := []string{}
-	// because pay_invoice is enabled even
-	// when there are no permissions set
 	for _, appPerm := range appPermissions {
 		if appPerm.RequestMethod == NIP_47_PAY_INVOICE_METHOD {
+			//find the pay_invoice-specific permissions
 			appPermission = appPerm
-		} else {
-			requestMethods = append(requestMethods, appPerm.RequestMethod)
 		}
+		requestMethods = append(requestMethods, nip47MethodDescriptions[appPerm.RequestMethod])
 	}
 
 	renewsIn := ""

--- a/views/apps/new.html
+++ b/views/apps/new.html
@@ -14,7 +14,6 @@
   <p class="mb-4 text-sm font-medium text-gray-900 dark:text-white"></p>
 
   <div id="RequestMethodOptions" class=" mt-4">
-    <input type="hidden" name="RequestMethods" id="RequestMethods" value={{if .RequestMethods}}{{.RequestMethods}}{{else}}{{"pay_invoice"}}{{end}}>
     <div class="mb-6">
       <p class="text-sm text-gray-500 dark:text-gray-400 mb-4"> Authorize {{ if .Name }}{{ .Name }}{{ else }}the new app{{end}} access to:</p>
       <ul class="items-center w-full sm:flex">
@@ -41,6 +40,7 @@
       <input type="hidden" name="_csrf" value="{{.Csrf}}">
       <input type="hidden" name="pubkey" value="{{.Pubkey}}" />
       <input type="hidden" name="returnTo" value="{{.ReturnTo}}" />
+      <input type="hidden" name="RequestMethods" id="RequestMethods" value={{if .RequestMethods}}{{.RequestMethods}}{{else}}{{"pay_invoice"}}{{end}}>
       {{ if eq .Name "" }}
         <div class="mb-4">
           <label

--- a/views/apps/new.html
+++ b/views/apps/new.html
@@ -14,15 +14,13 @@
   <p class="mb-4 text-sm font-medium text-gray-900 dark:text-white">Authorize {{ if .Name }}{{ .Name }}{{ else }}the new app{{end}} access to:</p>
 
   <ul class="mb-6">
+    {{range $key, $value := .RequestMethodHelper}}
+    {{ if $value.Checked}}
     <li class="mb-2 relative pl-6">
        <span class="absolute left-0 text-green-500">✓</span>
-       Send payments from your wallet.
+       {{ $value.Description }}
     </li>
-    {{range .RequestMethodDescriptions}}
-    <li class="mb-2 relative pl-6">
-       <span class="absolute left-0 text-green-500">✓</span>
-       {{ . }}
-    </li>
+    {{end}}
     {{end}}
   </ul>
 
@@ -150,18 +148,14 @@
           <p class="text-sm font-medium text-gray-900 dark:text-gray-300 mb-1">Set request permissions</p>
           <p class="text-sm text-gray-500 dark:text-gray-400 mb-4">Finetune the application's permissions.</p>
           <ul class="items-center w-full sm:flex">
+            {{range $key, $value := .RequestMethodHelper}}
             <li class="w-full">
               <div class="flex items-center pl-3">
-                <input {{if .RequestMethodDescriptions}}checked{{end}} id="GetBalance" type="checkbox" value="get_balance" class="w-4 h-4 text-purple-700 bg-gray-50 border border-gray-300 rounded focus:ring-purple-700 dark:focus:ring-purple-600 dark:ring-offset-gray-800 focus:ring-2 dark:bg-surface-00dp dark:border-gray-700">
-                <label for="GetBalance" class="ml-2 text-sm font-medium text-gray-900 dark:text-gray-300">Read your balance</label>
+                <input {{if  $value.Checked }} checked {{end}} id="{{$key}}-id" type="checkbox" value="{{ $key }}" class="w-4 h-4 text-purple-700 bg-gray-50 border border-gray-300 rounded focus:ring-purple-700 dark:focus:ring-purple-600 dark:ring-offset-gray-800 focus:ring-2 dark:bg-surface-00dp dark:border-gray-700">
+                <label for="PayInvoice" class="ml-2 text-sm font-medium text-gray-500 dark:text-gray-400">{{ $value.Description}}</label>
               </div>
             </li>
-            <li class="w-full">
-              <div class="flex items-center pl-3">
-                <input checked disabled id="PayInvoice" type="checkbox" value="pay_invoice" class="w-4 h-4 text-purple-700 bg-gray-50 border border-gray-300 rounded focus:ring-purple-700 dark:focus:ring-purple-600 dark:ring-offset-gray-800 focus:ring-2 dark:bg-surface-00dp dark:border-gray-700">
-                <label for="PayInvoice" class="ml-2 text-sm font-medium text-gray-500 dark:text-gray-400">Send payments</label>
-              </div>
-            </li>
+            {{ end }}
           </ul>
         </div>
       </div>

--- a/views/apps/new.html
+++ b/views/apps/new.html
@@ -11,18 +11,24 @@
     {{end}}
   </h2>
 
-  <p class="mb-4 text-sm font-medium text-gray-900 dark:text-white">Authorize {{ if .Name }}{{ .Name }}{{ else }}the new app{{end}} access to:</p>
+  <p class="mb-4 text-sm font-medium text-gray-900 dark:text-white"></p>
 
-  <ul class="mb-6">
-    {{range $key, $value := .RequestMethodHelper}}
-    {{ if $value.Checked}}
-    <li class="mb-2 relative pl-6">
-       <span class="absolute left-0 text-green-500">✓</span>
-       {{ $value.Description }}
-    </li>
-    {{end}}
-    {{end}}
-  </ul>
+  <div id="RequestMethodOptions" class=" mt-4">
+    <input type="hidden" name="RequestMethods" id="RequestMethods" value={{if .RequestMethods}}{{.RequestMethods}}{{else}}{{"pay_invoice"}}{{end}}>
+    <div class="mb-6">
+      <p class="text-sm text-gray-500 dark:text-gray-400 mb-4"> Authorize {{ if .Name }}{{ .Name }}{{ else }}the new app{{end}} access to:</p>
+      <ul class="items-center w-full sm:flex">
+        {{range $key, $value := .RequestMethodHelper}}
+        <li class="w-full">
+          <div class="flex items-center pl-3">
+            <input {{if  $value.Checked }} checked {{end}} id="{{$key}}-id" type="checkbox" value="{{ $key }}" class="w-4 h-4 text-purple-700 bg-gray-50 border border-gray-300 rounded focus:ring-purple-700 dark:focus:ring-purple-600 dark:ring-offset-gray-800 focus:ring-2 dark:bg-surface-00dp dark:border-gray-700">
+            <label for="{{$key}}-id" class="ml-2 text-sm font-medium text-gray-500 dark:text-gray-400">{{ $value.Description}}</label>
+          </div>
+        </li>
+        {{ end }}
+      </ul>
+    </div>
+  </div>
 
   {{ if .Disabled }}
   <p class="text-blue-700 bg-blue-50 p-3 mb-6">
@@ -142,23 +148,7 @@
           </ul>
         </div>
       </div>
-      <div id="RequestMethodOptions" class=" mt-4">
-        <input type="hidden" name="RequestMethods" id="RequestMethods" value={{if .RequestMethods}}{{.RequestMethods}}{{else}}{{"pay_invoice"}}{{end}}>
-        <div class="mb-6">
-          <p class="text-sm font-medium text-gray-900 dark:text-gray-300 mb-1">Set request permissions</p>
-          <p class="text-sm text-gray-500 dark:text-gray-400 mb-4">Finetune the application's permissions.</p>
-          <ul class="items-center w-full sm:flex">
-            {{range $key, $value := .RequestMethodHelper}}
-            <li class="w-full">
-              <div class="flex items-center pl-3">
-                <input {{if  $value.Checked }} checked {{end}} id="{{$key}}-id" type="checkbox" value="{{ $key }}" class="w-4 h-4 text-purple-700 bg-gray-50 border border-gray-300 rounded focus:ring-purple-700 dark:focus:ring-purple-600 dark:ring-offset-gray-800 focus:ring-2 dark:bg-surface-00dp dark:border-gray-700">
-                <label for="PayInvoice" class="ml-2 text-sm font-medium text-gray-500 dark:text-gray-400">{{ $value.Description}}</label>
-              </div>
-            </li>
-            {{ end }}
-          </ul>
-        </div>
-      </div>
+
     </div>
     {{ if .Pubkey }}
       <p class="text-orange-700 bg-orange-50 p-3 mb-6">

--- a/views/apps/show.html
+++ b/views/apps/show.html
@@ -30,7 +30,7 @@
               {{ . }}
             </li>
           {{end}}
-        {{ if not .AppPermission.ExpiresAt.IsZero}}
+        {{ if not .ExpiresAt.IsZero}}
         <li class="mb-2 relative pl-6">
           <p>
             <span class="dark:text-white">Expiry:</span> {{.AppPermission.ExpiresAt}}

--- a/views/apps/show.html
+++ b/views/apps/show.html
@@ -24,22 +24,12 @@
     <div class="py-4">
       <h3 class="text-xl font-headline dark:text-white">Permissions</h3>
       <ul class="mt-2 text-sm text-gray-500 dark:text-gray-400">
-        {{ if .RequestMethods}}
           {{range .RequestMethods}}
-            {{if eq . "pay_invoice"}}
             <li class="mb-2 relative pl-6">
               <span class="absolute left-0 text-green-500">✓</span>
-              Send payments from your wallet
+              {{ . }}
             </li>
-            {{end}}
-            {{if eq . "get_balance"}}
-            <li class="mb-2 relative pl-6">
-              <span class="absolute left-0 text-green-500">✓</span>
-              View your wallet balance
-            </li>
-            {{end}}
           {{end}}
-        {{end}}
         {{ if not .AppPermission.ExpiresAt.IsZero}}
         <li class="mb-2 relative pl-6">
           <p>

--- a/views/apps/show.html
+++ b/views/apps/show.html
@@ -33,26 +33,26 @@
         {{ if not .ExpiresAt.IsZero}}
         <li class="mb-2 relative pl-6">
           <p>
-            <span class="dark:text-white">Expiry:</span> {{.AppPermission.ExpiresAt}}
+            <span class="dark:text-white">Expiry:</span> {{.ExpiresAt}}
           </p>
         </li>
         {{end}}
-        {{ if gt .AppPermission.MaxAmount 0 }}
+        {{ if gt .PaySpecificPermision.MaxAmount 0 }}
         <li class="mb-2 relative pl-6">
           <p>
-            <span class="dark:text-white">Budget Amount:</span> {{.AppPermission.MaxAmount}}
+            <span class="dark:text-white">Budget Amount:</span> {{.PaySpecificPermision.MaxAmount}}
           </p>
         </li>
         {{end}}
-        {{ if gt .AppPermission.MaxAmount 0 }}
+        {{ if gt .PaySpecificPermision.MaxAmount 0 }}
         <li class="mb-2 relative pl-6">
           <p>
-            <span class="dark:text-white">Current usage:</span> {{.BudgetUsage}} / {{.AppPermission.MaxAmount}} sats
+            <span class="dark:text-white">Current usage:</span> {{.BudgetUsage}} / {{.PaySpecificPermision.MaxAmount}} sats
           </p>
         </li>
         <li class="mb-2 relative pl-6">
           <p>
-            <span class="dark:text-white">Renews in:</span> {{.RenewsIn}} (set to {{.AppPermission.BudgetRenewal}})
+            <span class="dark:text-white">Renews in:</span> {{.RenewsIn}} (set to {{.PaySpecificPermision.BudgetRenewal}})
           </p>
         </li>
         {{ end  }}


### PR DESCRIPTION
There is currently an issue because there are several places where the `pay_invoice` permission is handled in a special way. In this PR this is mostly removed. This causes a bug in the current master where an app that has both `get_balance` and `pay_invoice` permissions is not in fact able to pay invoices.

- We now create app_permissions based on what the client requests, no more special treatment of the pay_invoice permission.
- From now on we never create an app without permissions.
- budgets have no meaning for non-pay-invoice-requests. 
- Removes hard-coded front-end code for the permissions' description, this is now set from the backend.