### PR TITLE
Pass client app name as state parameter to oauth connection

### DIFF
--- a/alby.go
+++ b/alby.go
@@ -329,6 +329,7 @@ func (svc *AlbyOAuthService) SendPaymentSync(ctx context.Context, senderPubkey, 
 }
 
 func (svc *AlbyOAuthService) AuthHandler(c echo.Context) error {
+	appName := c.QueryParam("c") // c - for client
 	// clear current session
 	sess, _ := session.Get(CookieName, c)
 	if sess.Values["user_id"] != nil {
@@ -341,7 +342,7 @@ func (svc *AlbyOAuthService) AuthHandler(c echo.Context) error {
 		sess.Save(c.Request(), c.Response())
 	}
 
-	url := svc.oauthConf.AuthCodeURL("")
+	url := svc.oauthConf.AuthCodeURL(appName) // pass on the appName as state
 	return c.Redirect(302, url)
 }
 

--- a/echo_handlers.go
+++ b/echo_handlers.go
@@ -268,7 +268,7 @@ func (svc *Service) AppsNewHandler(c echo.Context) error {
 			sess.Options.Domain = svc.cfg.CookieDomain
 		}
 		sess.Save(c.Request(), c.Response())
-		return c.Redirect(302, fmt.Sprintf("/%s/auth", strings.ToLower(svc.cfg.LNBackendType)))
+		return c.Redirect(302, fmt.Sprintf("/%s/auth?c=%s", strings.ToLower(svc.cfg.LNBackendType), appName))
 	}
 
 	//construction to return a map with all possible permissions


### PR DESCRIPTION
this helps to keep the context and give users context related info