### PR TITLE
fix: make preimage a nullable string

### DIFF
--- a/handle_payment_request.go
+++ b/handle_payment_request.go
@@ -98,7 +98,7 @@ func (svc *Service) HandlePayInvoiceEvent(ctx context.Context, request *Nip47Req
 			},
 		}, ss)
 	}
-	payment.Preimage = preimage
+	payment.Preimage = &preimage
 	nostrEvent.State = NOSTR_EVENT_STATE_HANDLER_EXECUTED
 	svc.db.Save(&nostrEvent)
 	svc.db.Save(&payment)

--- a/main.go
+++ b/main.go
@@ -85,6 +85,13 @@ func main() {
 		log.Fatalf("Failed migrate DB %v", err)
 	}
 
+	// Update payments with preimage as an empty string to use NULL instead
+	// TODO: remove this migration in a future release and make preimage column unique
+	if err := db.Table("payments").Where("preimage = ?", "").Update("preimage", nil).Error; err != nil {
+		log.Fatalf("Failed to update preimage from empty string to NULL: %v", err)
+	}
+
+
 	if cfg.NostrSecretKey == "" {
 		if cfg.LNBackendType == AlbyBackendType {
 			//not allowed

--- a/models.go
+++ b/models.go
@@ -105,7 +105,7 @@ type Payment struct {
 	NostrEvent     NostrEvent
 	Amount         uint
 	PaymentRequest string
-	Preimage       string
+	Preimage       *string
 	CreatedAt      time.Time
 	UpdatedAt      time.Time
 }


### PR DESCRIPTION
Related to https://github.com/getAlby/nostr-wallet-connect/issues/138 

I think the preimage should not be able to be stored as an empty string (then we cannot make add a unique constraint)

The query in GetBudgetUsage is working incorrectly because it's checking `preimage IS NOT NULL` which always passes.

A follow up PR needs to be added to add the unique constraint, once this has been run.