### PR TITLE
fix(handle payment request): lowercase bolt11 invoice

### DIFF
--- a/handle_payment_request.go
+++ b/handle_payment_request.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strings"
 
 	"github.com/nbd-wtf/go-nostr"
 	decodepay "github.com/nbd-wtf/ln-decodepay"
@@ -36,6 +37,8 @@ func (svc *Service) HandlePayInvoiceEvent(ctx context.Context, request *Nip47Req
 	}
 
 	bolt11 = payParams.Invoice
+	// Convert invoice to lowercase string
+	bolt11 = strings.ToLower(bolt11)
 	paymentRequest, err := decodepay.Decodepay(bolt11)
 	if err != nil {
 		svc.Logger.WithFields(logrus.Fields{


### PR DESCRIPTION
This PR closes #184.  
The problem lies in [this](https://github.com/lightningnetwork/lnd/blob/30348baedcd9e9b157c4cdbf7f0c322fff20cc68/zpay32/decode.go#L59-L62) code block of the `decode.go` file in the `zpay32` package of `lnd`:  
```go
if !strings.HasPrefix(hrp[2:], expectedPrefix) {
	return nil, fmt.Errorf(
	"invoice not for current active network '%s'", net.Name)
}
```

Submitting an uppercase *Bolt11* invoice sets the condition to always be false and triggers that error.  
The associated commit in this pull request enforces the lowercase conversion of the invoice before all the processing take place, thereby eliminating the problem at its root.  
  

I have tested it using `go test`, and the issue does not arise when hardcoding an uppercase invoice in `service_test.go`

