### PR TITLE
fix: make timestamps numbers to follow NIP-47

### DIFF
--- a/alby.go
+++ b/alby.go
@@ -709,6 +709,18 @@ func albyInvoiceToTransaction(invoice *AlbyInvoice) *Nip47Transaction {
 		preimage = invoice.Preimage
 	}
 
+	var expiresAt *int64
+	if invoice.ExpiresAt != nil {
+		expiresAtUnix := invoice.ExpiresAt.Unix()
+		expiresAt = &expiresAtUnix
+	}
+
+	var settledAt *int64
+	if invoice.SettledAt != nil {
+		settledAtUnix := invoice.SettledAt.Unix()
+		settledAt = &settledAtUnix
+	}
+
 	return &Nip47Transaction{
 		Type:            invoice.Type,
 		Invoice:         invoice.PaymentRequest,
@@ -718,9 +730,9 @@ func albyInvoiceToTransaction(invoice *AlbyInvoice) *Nip47Transaction {
 		PaymentHash:     invoice.PaymentHash,
 		Amount:          invoice.Amount * 1000,
 		FeesPaid:        0, // TODO: support fees
-		CreatedAt:       invoice.CreatedAt,
-		ExpiresAt:       invoice.ExpiresAt,
-		SettledAt:       invoice.SettledAt,
+		CreatedAt:       invoice.CreatedAt.Unix(),
+		ExpiresAt:       expiresAt,
+		SettledAt:       settledAt,
 		Metadata:        invoice.Metadata,
 	}
 }

--- a/models.go
+++ b/models.go
@@ -135,9 +135,9 @@ type Nip47Transaction struct {
 	PaymentHash     string      `json:"payment_hash"`
 	Amount          int64       `json:"amount"`
 	FeesPaid        int64       `json:"fees_paid"`
-	CreatedAt       time.Time   `json:"created_at"`
-	ExpiresAt       *time.Time  `json:"expires_at"`
-	SettledAt       *time.Time  `json:"settled_at"`
+	CreatedAt       int64       `json:"created_at"`
+	ExpiresAt       *int64      `json:"expires_at"`
+	SettledAt       *int64      `json:"settled_at"`
 	Metadata        interface{} `json:"metadata,omitempty"`
 }
 

--- a/service_test.go
+++ b/service_test.go
@@ -111,6 +111,7 @@ var mockNodeInfo = NodeInfo{
 }
 
 var mockTime = time.Unix(1693876963, 0)
+var mockTimeUnix = mockTime.Unix()
 
 var mockTransactions = []Nip47Transaction{
 	{
@@ -122,7 +123,7 @@ var mockTransactions = []Nip47Transaction{
 		PaymentHash:     "payment_hash_1",
 		Amount:          1000,
 		FeesPaid:        50,
-		SettledAt:       &mockTime,
+		SettledAt:       &mockTimeUnix,
 		Metadata: map[string]interface{}{
 			"key1": "value1",
 			"key2": 42,
@@ -137,7 +138,7 @@ var mockTransactions = []Nip47Transaction{
 		PaymentHash:     "payment_hash_2",
 		Amount:          2000,
 		FeesPaid:        75,
-		SettledAt:       &mockTime,
+		SettledAt:       &mockTimeUnix,
 	},
 }
 var mockTransaction = &mockTransactions[0]
@@ -571,7 +572,7 @@ func TestHandleEvent(t *testing.T) {
 	assert.Equal(t, mockTransactions[0].PaymentHash, transaction.PaymentHash)
 	assert.Equal(t, mockTransactions[0].Amount, transaction.Amount)
 	assert.Equal(t, mockTransactions[0].FeesPaid, transaction.FeesPaid)
-	assert.Equal(t, mockTransactions[0].SettledAt.Unix(), transaction.SettledAt.Unix())
+	assert.Equal(t, mockTransactions[0].SettledAt, transaction.SettledAt)
 
 	// get_info: without permission
 	newPayload, err = nip04.Encrypt(nip47GetInfoJson, ss)


### PR DESCRIPTION
fixes https://github.com/getAlby/nostr-wallet-connect/issues/204

also fixes expiresAt in lndInvoiceToTransaction function (was incorrectly using settledAt)