### PR TITLE
Chore: remove multi_* incompatible fields from NostrEvent model

### DIFF
--- a/handle_balance_request.go
+++ b/handle_balance_request.go
@@ -14,7 +14,7 @@ const (
 
 func (svc *Service) HandleGetBalanceEvent(ctx context.Context, request *Nip47Request, event *nostr.Event, app App, ss []byte) (result *nostr.Event, err error) {
 
-	nostrEvent := NostrEvent{App: app, NostrId: event.ID, Content: event.Content, State: "received"}
+	nostrEvent := NostrEvent{App: app, NostrId: event.ID, Content: event.Content}
 	err = svc.db.Create(&nostrEvent).Error
 	if err != nil {
 		svc.Logger.WithFields(logrus.Fields{
@@ -55,7 +55,6 @@ func (svc *Service) HandleGetBalanceEvent(ctx context.Context, request *Nip47Req
 			"eventKind": event.Kind,
 			"appId":     app.ID,
 		}).Infof("Failed to fetch balance: %v", err)
-		nostrEvent.State = NOSTR_EVENT_STATE_HANDLER_ERROR
 		svc.db.Save(&nostrEvent)
 		return svc.createResponse(event, Nip47Response{
 			ResultType: NIP_47_GET_BALANCE_METHOD,
@@ -79,7 +78,6 @@ func (svc *Service) HandleGetBalanceEvent(ctx context.Context, request *Nip47Req
 		responsePayload.BudgetRenewal = appPermission.BudgetRenewal
 	}
 
-	nostrEvent.State = NOSTR_EVENT_STATE_HANDLER_EXECUTED
 	svc.db.Save(&nostrEvent)
 	return svc.createResponse(event, Nip47Response{
 		ResultType: NIP_47_GET_BALANCE_METHOD,

--- a/handle_info_request.go
+++ b/handle_info_request.go
@@ -10,7 +10,7 @@ import (
 
 func (svc *Service) HandleGetInfoEvent(ctx context.Context, request *Nip47Request, event *nostr.Event, app App, ss []byte) (result *nostr.Event, err error) {
 
-	nostrEvent := NostrEvent{App: app, NostrId: event.ID, Content: event.Content, State: "received"}
+	nostrEvent := NostrEvent{App: app, NostrId: event.ID, Content: event.Content}
 	err = svc.db.Create(&nostrEvent).Error
 	if err != nil {
 		svc.Logger.WithFields(logrus.Fields{
@@ -51,7 +51,6 @@ func (svc *Service) HandleGetInfoEvent(ctx context.Context, request *Nip47Reques
 			"eventKind": event.Kind,
 			"appId":     app.ID,
 		}).Infof("Failed to fetch node info: %v", err)
-		nostrEvent.State = NOSTR_EVENT_STATE_HANDLER_ERROR
 		svc.db.Save(&nostrEvent)
 		return svc.createResponse(event, Nip47Response{
 			ResultType: request.Method,
@@ -72,7 +71,6 @@ func (svc *Service) HandleGetInfoEvent(ctx context.Context, request *Nip47Reques
 		Methods:     svc.GetMethods(&app),
 	}
 
-	nostrEvent.State = NOSTR_EVENT_STATE_HANDLER_EXECUTED
 	svc.db.Save(&nostrEvent)
 	return svc.createResponse(event, Nip47Response{
 		ResultType: request.Method,

--- a/handle_list_transactions_request.go
+++ b/handle_list_transactions_request.go
@@ -11,7 +11,7 @@ import (
 
 func (svc *Service) HandleListTransactionsEvent(ctx context.Context, request *Nip47Request, event *nostr.Event, app App, ss []byte) (result *nostr.Event, err error) {
 
-	nostrEvent := NostrEvent{App: app, NostrId: event.ID, Content: event.Content, State: "received"}
+	nostrEvent := NostrEvent{App: app, NostrId: event.ID, Content: event.Content}
 	err = svc.db.Create(&nostrEvent).Error
 	if err != nil {
 		svc.Logger.WithFields(logrus.Fields{
@@ -66,7 +66,6 @@ func (svc *Service) HandleListTransactionsEvent(ctx context.Context, request *Ni
 			"eventKind": event.Kind,
 			"appId":     app.ID,
 		}).Infof("Failed to fetch transactions: %v", err)
-		nostrEvent.State = NOSTR_EVENT_STATE_HANDLER_ERROR
 		svc.db.Save(&nostrEvent)
 		return svc.createResponse(event, Nip47Response{
 			ResultType: request.Method,
@@ -82,7 +81,6 @@ func (svc *Service) HandleListTransactionsEvent(ctx context.Context, request *Ni
 	}
 	// fmt.Println(responsePayload)
 
-	nostrEvent.State = NOSTR_EVENT_STATE_HANDLER_EXECUTED
 	svc.db.Save(&nostrEvent)
 	return svc.createResponse(event, Nip47Response{
 		ResultType: request.Method,

--- a/handle_lookup_invoice_request.go
+++ b/handle_lookup_invoice_request.go
@@ -13,7 +13,7 @@ import (
 
 func (svc *Service) HandleLookupInvoiceEvent(ctx context.Context, request *Nip47Request, event *nostr.Event, app App, ss []byte) (result *nostr.Event, err error) {
 	// TODO: move to a shared function
-	nostrEvent := NostrEvent{App: app, NostrId: event.ID, Content: event.Content, State: "received"}
+	nostrEvent := NostrEvent{App: app, NostrId: event.ID, Content: event.Content}
 	err = svc.db.Create(&nostrEvent).Error
 	if err != nil {
 		svc.Logger.WithFields(logrus.Fields{
@@ -94,7 +94,6 @@ func (svc *Service) HandleLookupInvoiceEvent(ctx context.Context, request *Nip47
 			"invoice":     lookupInvoiceParams.Invoice,
 			"paymentHash": lookupInvoiceParams.PaymentHash,
 		}).Infof("Failed to lookup invoice: %v", err)
-		nostrEvent.State = NOSTR_EVENT_STATE_HANDLER_ERROR
 		svc.db.Save(&nostrEvent)
 		return svc.createResponse(event, Nip47Response{
 			ResultType: NIP_47_LOOKUP_INVOICE_METHOD,
@@ -109,7 +108,6 @@ func (svc *Service) HandleLookupInvoiceEvent(ctx context.Context, request *Nip47
 		Nip47Transaction: *transaction,
 	}
 
-	nostrEvent.State = NOSTR_EVENT_STATE_HANDLER_EXECUTED
 	svc.db.Save(&nostrEvent)
 	return svc.createResponse(event, Nip47Response{
 		ResultType: NIP_47_LOOKUP_INVOICE_METHOD,

--- a/handle_make_invoice_request.go
+++ b/handle_make_invoice_request.go
@@ -14,7 +14,7 @@ import (
 func (svc *Service) HandleMakeInvoiceEvent(ctx context.Context, request *Nip47Request, event *nostr.Event, app App, ss []byte) (result *nostr.Event, err error) {
 
 	// TODO: move to a shared function
-	nostrEvent := NostrEvent{App: app, NostrId: event.ID, Content: event.Content, State: "received"}
+	nostrEvent := NostrEvent{App: app, NostrId: event.ID, Content: event.Content}
 	err = svc.db.Create(&nostrEvent).Error
 	if err != nil {
 		svc.Logger.WithFields(logrus.Fields{
@@ -92,7 +92,6 @@ func (svc *Service) HandleMakeInvoiceEvent(ctx context.Context, request *Nip47Re
 			"descriptionHash": makeInvoiceParams.DescriptionHash,
 			"expiry":          makeInvoiceParams.Expiry,
 		}).Infof("Failed to make invoice: %v", err)
-		nostrEvent.State = NOSTR_EVENT_STATE_HANDLER_ERROR
 		svc.db.Save(&nostrEvent)
 		return svc.createResponse(event, Nip47Response{
 			ResultType: NIP_47_MAKE_INVOICE_METHOD,
@@ -107,7 +106,6 @@ func (svc *Service) HandleMakeInvoiceEvent(ctx context.Context, request *Nip47Re
 		Nip47Transaction: *transaction,
 	}
 
-	nostrEvent.State = NOSTR_EVENT_STATE_HANDLER_EXECUTED
 	svc.db.Save(&nostrEvent)
 	return svc.createResponse(event, Nip47Response{
 		ResultType: NIP_47_MAKE_INVOICE_METHOD,

--- a/handle_pay_keysend_request.go
+++ b/handle_pay_keysend_request.go
@@ -11,7 +11,7 @@ import (
 
 func (svc *Service) HandlePayKeysendEvent(ctx context.Context, request *Nip47Request, event *nostr.Event, app App, ss []byte) (result *nostr.Event, err error) {
 
-	nostrEvent := NostrEvent{App: app, NostrId: event.ID, Content: event.Content, State: "received"}
+	nostrEvent := NostrEvent{App: app, NostrId: event.ID, Content: event.Content}
 	err = svc.db.Create(&nostrEvent).Error
 	if err != nil {
 		svc.Logger.WithFields(logrus.Fields{
@@ -73,7 +73,6 @@ func (svc *Service) HandlePayKeysendEvent(ctx context.Context, request *Nip47Req
 			"appId":        app.ID,
 			"senderPubkey": payParams.Pubkey,
 		}).Infof("Failed to send payment: %v", err)
-		nostrEvent.State = NOSTR_EVENT_STATE_HANDLER_ERROR
 		svc.db.Save(&nostrEvent)
 		return svc.createResponse(event, Nip47Response{
 			ResultType: request.Method,
@@ -84,7 +83,6 @@ func (svc *Service) HandlePayKeysendEvent(ctx context.Context, request *Nip47Req
 		}, nostr.Tags{}, ss)
 	}
 	payment.Preimage = &preimage
-	nostrEvent.State = NOSTR_EVENT_STATE_HANDLER_EXECUTED
 	svc.db.Save(&nostrEvent)
 	svc.db.Save(&payment)
 	return svc.createResponse(event, Nip47Response{

--- a/handle_payment_request.go
+++ b/handle_payment_request.go
@@ -13,7 +13,7 @@ import (
 
 func (svc *Service) HandlePayInvoiceEvent(ctx context.Context, request *Nip47Request, event *nostr.Event, app App, ss []byte) (result *nostr.Event, err error) {
 
-	nostrEvent := NostrEvent{App: app, NostrId: event.ID, Content: event.Content, State: "received"}
+	nostrEvent := NostrEvent{App: app, NostrId: event.ID, Content: event.Content}
 	err = svc.db.Create(&nostrEvent).Error
 	if err != nil {
 		svc.Logger.WithFields(logrus.Fields{
@@ -94,7 +94,6 @@ func (svc *Service) HandlePayInvoiceEvent(ctx context.Context, request *Nip47Req
 			"appId":     app.ID,
 			"bolt11":    bolt11,
 		}).Infof("Failed to send payment: %v", err)
-		nostrEvent.State = NOSTR_EVENT_STATE_HANDLER_ERROR
 		svc.db.Save(&nostrEvent)
 		return svc.createResponse(event, Nip47Response{
 			ResultType: NIP_47_PAY_INVOICE_METHOD,
@@ -105,7 +104,6 @@ func (svc *Service) HandlePayInvoiceEvent(ctx context.Context, request *Nip47Req
 		}, nostr.Tags{}, ss)
 	}
 	payment.Preimage = &preimage
-	nostrEvent.State = NOSTR_EVENT_STATE_HANDLER_EXECUTED
 	svc.db.Save(&nostrEvent)
 	svc.db.Save(&payment)
 	return svc.createResponse(event, Nip47Response{

--- a/models.go
+++ b/models.go
@@ -105,10 +105,8 @@ type NostrEvent struct {
 	AppId     uint `validate:"required"`
 	App       App
 	NostrId   string `validate:"required"`
-	ReplyId   string
 	Content   string
-	State     string
-	RepliedAt time.Time
+	RepliedAt time.Time // for multi_* events this will be the last reply
 	CreatedAt time.Time
 	UpdatedAt time.Time
 }


### PR DESCRIPTION
Models
- NostrEvent.ReplyId does not support multiple replies per event. I think we should just remove it. It doesn't seem to be used or important for debugging or analytics. I think we can just use the logs
- NostrEvent.State - does not support multiple replies per event, also IMO it is broken because the final state (NOSTR_EVENT_STATE_HANDLER_EXECUTED) overwrites NOSTR_EVENT_STATE_HANDLER_ERROR if the reply is published successfully. I think this should also be removed and just use the logs.
- NostrEvent.RepliedAt - we can use the last reply time here I guess. I think the field is useful.