### PR TITLE
chore: dry up eos

### DIFF
--- a/service.go
+++ b/service.go
@@ -29,13 +29,12 @@ import (
 
 type Service struct {
 	// config from .env only. Fetch dynamic config from db
-	cfg         *Config
-	db          *gorm.DB
-	lnClient    LNClient
-	ReceivedEOS bool
-	Logger      *logrus.Logger
-	ctx         context.Context
-	wg          *sync.WaitGroup
+	cfg      *Config
+	db       *gorm.DB
+	lnClient LNClient
+	Logger   *logrus.Logger
+	ctx      context.Context
+	wg       *sync.WaitGroup
 }
 
 // TODO: move to service.go
@@ -165,12 +164,11 @@ func (svc *Service) noticeHandler(notice string) {
 
 func (svc *Service) StartSubscription(ctx context.Context, sub *nostr.Subscription) error {
 	go func() {
+		// block till EOS is received
 		<-sub.EndOfStoredEvents
-		svc.ReceivedEOS = true
 		svc.Logger.Info("Received EOS")
-	}()
 
-	go func() {
+		// loop through incoming events
 		for event := range sub.Events {
 			go func(event *nostr.Event) {
 				resp, err := svc.HandleEvent(ctx, event)
@@ -255,10 +253,6 @@ func (svc *Service) StartSubscription(ctx context.Context, sub *nostr.Subscripti
 }
 
 func (svc *Service) HandleEvent(ctx context.Context, event *nostr.Event) (result *nostr.Event, err error) {
-	//don't process historical events
-	if !svc.ReceivedEOS {
-		return nil, nil
-	}
 	svc.Logger.WithFields(logrus.Fields{
 		"eventId":   event.ID,
 		"eventKind": event.Kind,

--- a/service_test.go
+++ b/service_test.go
@@ -149,14 +149,6 @@ func TestHandleEvent(t *testing.T) {
 	ctx := context.TODO()
 	svc, _ := createTestService(t)
 	defer os.Remove(testDB)
-	//test not yet receivedEOS
-	res, err := svc.HandleEvent(ctx, &nostr.Event{
-		Kind: NIP_47_REQUEST_KIND,
-	})
-	assert.Nil(t, res)
-	assert.Nil(t, err)
-	//now signal that we are ready to receive events
-	svc.ReceivedEOS = true
 
 	senderPrivkey := nostr.GeneratePrivateKey()
 	senderPubkey, err := nostr.GetPublicKey(senderPrivkey)
@@ -166,7 +158,7 @@ func TestHandleEvent(t *testing.T) {
 	assert.NoError(t, err)
 	payload, err := nip04.Encrypt(nip47PayJson, ss)
 	assert.NoError(t, err)
-	res, err = svc.HandleEvent(ctx, &nostr.Event{
+	res, err := svc.HandleEvent(ctx, &nostr.Event{
 		ID:      "test_event_1",
 		Kind:    NIP_47_REQUEST_KIND,
 		PubKey:  senderPubkey,
@@ -646,10 +638,9 @@ func createTestService(t *testing.T) (svc *Service, ln LNClient) {
 			NostrSecretKey: sk,
 			NostrPublicKey: pk,
 		},
-		db:          gormDb,
-		lnClient:    ln,
-		ReceivedEOS: false,
-		Logger:      logger,
+		db:       gormDb,
+		lnClient: ln,
+		Logger:   logger,
 	}, ln
 }
 


### PR DESCRIPTION
Instead of waiting till we reach EOS in one goroutine and concurrently looping through the already responded events in another goroutine, we can just block till we reach EOS in the same goroutine and then loop through events. That way we don't even have to check if it reached EOS.

And hence removes the need of an additional go routine and the unnecessary check for ReceivedEOS and also removes it from the Service model as a whole.


