### PR TITLE
Feat: unlock screen (WIP)

### DIFF
--- a/api.go
+++ b/api.go
@@ -222,6 +222,8 @@ func (api *API) Start(startRequest *models.StartRequest) error {
 }
 
 func (api *API) Setup(setupRequest *models.SetupRequest) error {
+	api.svc.cfg.SavePasswordCheck(setupRequest.UnlockPassword)
+
 	// only update non-empty values
 	if setupRequest.LNBackendType != "" {
 		api.svc.cfg.SetUpdate("LNBackendType", setupRequest.LNBackendType, "")

--- a/config.go
+++ b/config.go
@@ -16,6 +16,7 @@ const (
 	BreezBackendType     = "BREEZ"
 	SessionCookieName    = "session"
 	SessionCookieAuthKey = "authenticated"
+	UnlockPasswordCheck  = "THIS STRING SHOULD MATCH IF PASSWORD IS CORRECT"
 )
 
 type AppConfig struct {
@@ -126,6 +127,16 @@ func (cfg *Config) SetUpdate(key string, value string, encryptionKey string) {
 		DoUpdates: clause.AssignmentColumns([]string{"value"}),
 	}
 	cfg.set(key, value, clauses, encryptionKey)
+}
+
+func (cfg *Config) CheckUnlockPassword(encryptionKey string) bool {
+	decryptedValue, err := cfg.Get("UnlockPasswordCheck", encryptionKey)
+
+	return err == nil && decryptedValue == UnlockPasswordCheck
+}
+
+func (cfg *Config) SavePasswordCheck(encryptionKey string) {
+	cfg.SetUpdate("UnlockPasswordCheck", UnlockPasswordCheck, encryptionKey)
 }
 
 func randomHex(n int) (string, error) {

--- a/config.go
+++ b/config.go
@@ -12,9 +12,10 @@ import (
 )
 
 const (
-	LNDBackendType   = "LND"
-	BreezBackendType = "BREEZ"
-	CookieName       = "alby_nwc_session"
+	LNDBackendType       = "LND"
+	BreezBackendType     = "BREEZ"
+	SessionCookieName    = "session"
+	SessionCookieAuthKey = "authenticated"
 )
 
 type AppConfig struct {

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -18,6 +18,7 @@ import { AppsRedirect } from "src/components/redirects/AppsRedirect";
 import { StartRedirect } from "src/components/redirects/StartRedirect";
 import { HomeRedirect } from "src/components/redirects/HomeRedirect";
 import Unlock from "src/screens/Unlock";
+import { SetupRedirect } from "src/components/redirects/SetupRedirect";
 
 function App() {
   return (
@@ -36,7 +37,7 @@ function App() {
               }
             ></Route>
             <Route path="welcome" element={<Welcome />}></Route>
-            <Route path="setup">
+            <Route path="setup" element={<SetupRedirect />}>
               <Route path="" element={<Navigate to="password" replace />} />
               <Route path="password" element={<SetupPassword />} />
               <Route path="node" element={<SetupNode />} />

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -17,6 +17,7 @@ import Start from "src/screens/Start";
 import { AppsRedirect } from "src/components/redirects/AppsRedirect";
 import { StartRedirect } from "src/components/redirects/StartRedirect";
 import { HomeRedirect } from "src/components/redirects/HomeRedirect";
+import Unlock from "src/screens/Unlock";
 
 function App() {
   return (
@@ -47,6 +48,7 @@ function App() {
               <Route path="created" element={<AppCreated />} />
               <Route path="*" element={<NotFound />} />
             </Route>
+            <Route path="unlock" element={<Unlock />} />
             <Route path="about" element={<About />} />
           </Route>
           <Route path="/*" element={<NotFound />} />

--- a/frontend/src/components/redirects/AppsRedirect.tsx
+++ b/frontend/src/components/redirects/AppsRedirect.tsx
@@ -10,7 +10,7 @@ export function AppsRedirect() {
 
   // TODO: re-add login redirect: https://github.com/getAlby/nostr-wallet-connect/commit/59b041886098dda4ff38191e3dd704ec36360673
   React.useEffect(() => {
-    if (!info || info.running) {
+    if (!info || (info.running && info.unlocked)) {
       return;
     }
     navigate("/");

--- a/frontend/src/components/redirects/AppsRedirect.tsx
+++ b/frontend/src/components/redirects/AppsRedirect.tsx
@@ -2,17 +2,20 @@ import { useInfo } from "src/hooks/useInfo";
 import { Outlet, useLocation, useNavigate } from "react-router-dom";
 import React from "react";
 import Loading from "src/components/Loading";
+import { localStorageKeys } from "src/constants";
 
 export function AppsRedirect() {
   const { data: info } = useInfo();
   const location = useLocation();
   const navigate = useNavigate();
 
-  // TODO: re-add login redirect: https://github.com/getAlby/nostr-wallet-connect/commit/59b041886098dda4ff38191e3dd704ec36360673
   React.useEffect(() => {
     if (!info || (info.running && info.unlocked)) {
+      window.localStorage.removeItem(localStorageKeys.returnTo);
       return;
     }
+    const returnTo = location.pathname + location.search;
+    window.localStorage.setItem(localStorageKeys.returnTo, returnTo);
     navigate("/");
   }, [info, location, navigate]);
 

--- a/frontend/src/components/redirects/HomeRedirect.tsx
+++ b/frontend/src/components/redirects/HomeRedirect.tsx
@@ -2,6 +2,7 @@ import { useInfo } from "src/hooks/useInfo";
 import { useLocation, useNavigate } from "react-router-dom";
 import React from "react";
 import Loading from "src/components/Loading";
+import { localStorageKeys } from "src/constants";
 
 export function HomeRedirect() {
   const { data: info } = useInfo();
@@ -15,7 +16,8 @@ export function HomeRedirect() {
     let to: string | undefined;
     if (info.setupCompleted && info.running) {
       if (info.unlocked) {
-        to = "/apps";
+        const returnTo = window.localStorage.getItem(localStorageKeys.returnTo);
+        to = returnTo || "/apps";
       } else {
         to = "/unlock";
       }

--- a/frontend/src/components/redirects/HomeRedirect.tsx
+++ b/frontend/src/components/redirects/HomeRedirect.tsx
@@ -14,7 +14,11 @@ export function HomeRedirect() {
     }
     let to: string | undefined;
     if (info.setupCompleted && info.running) {
-      to = "/apps";
+      if (info.unlocked) {
+        to = "/apps";
+      } else {
+        to = "/unlock";
+      }
     } else if (info.setupCompleted && !info.running) {
       to = "/start";
     } else {

--- a/frontend/src/components/redirects/SetupRedirect.tsx
+++ b/frontend/src/components/redirects/SetupRedirect.tsx
@@ -1,0 +1,25 @@
+import { useInfo } from "src/hooks/useInfo";
+import { Outlet, useLocation, useNavigate } from "react-router-dom";
+import React from "react";
+import Loading from "src/components/Loading";
+
+export function SetupRedirect() {
+  const { data: info } = useInfo();
+  const location = useLocation();
+  const navigate = useNavigate();
+
+  React.useEffect(() => {
+    if (!info) {
+      return;
+    }
+    if (info.running && !info.unlocked) {
+      navigate("/");
+    }
+  }, [info, location, navigate]);
+
+  if (!info) {
+    return <Loading />;
+  }
+
+  return <Outlet />;
+}

--- a/frontend/src/constants.ts
+++ b/frontend/src/constants.ts
@@ -1,0 +1,3 @@
+export const localStorageKeys = {
+  returnTo: "returnTo",
+};

--- a/frontend/src/screens/Start.tsx
+++ b/frontend/src/screens/Start.tsx
@@ -33,7 +33,7 @@ export default function Start() {
       console.log({ res });
       await refetchInfo();
 
-      navigate("/apps");
+      navigate("/");
     } catch (error) {
       handleRequestError("Failed to connect", error);
     } finally {

--- a/frontend/src/screens/Unlock.tsx
+++ b/frontend/src/screens/Unlock.tsx
@@ -32,7 +32,7 @@ export default function Unlock() {
       });
       console.log({ res });
       await refetchInfo();
-      navigate("/apps");
+      navigate("/");
     } catch (error) {
       handleRequestError("Failed to connect", error);
     } finally {

--- a/frontend/src/screens/Unlock.tsx
+++ b/frontend/src/screens/Unlock.tsx
@@ -1,12 +1,12 @@
 import React from "react";
-import { Link, useNavigate } from "react-router-dom";
+import { useNavigate } from "react-router-dom";
 import { useCSRF } from "src/hooks/useCSRF";
 import { request } from "src/utils/request";
 import ConnectButton from "src/components/ConnectButton";
 import { handleRequestError } from "src/utils/handleRequestError";
 import { useInfo } from "src/hooks/useInfo";
 
-export default function Start() {
+export default function Unlock() {
   const [unlockPassword, setUnlockPassword] = React.useState("");
   const [loading, setLoading] = React.useState(false);
   const navigate = useNavigate();
@@ -20,7 +20,7 @@ export default function Start() {
       if (!csrf) {
         throw new Error("info not loaded");
       }
-      const res = await request("/api/start", {
+      const res = await request("/api/unlock", {
         method: "POST",
         headers: {
           "X-CSRF-Token": csrf,
@@ -32,7 +32,6 @@ export default function Start() {
       });
       console.log({ res });
       await refetchInfo();
-
       navigate("/apps");
     } catch (error) {
       handleRequestError("Failed to connect", error);
@@ -43,9 +42,9 @@ export default function Start() {
 
   return (
     <>
-      <h1 className="text-lg">Start NWC</h1>
+      <h1 className="text-lg">Unlock NWC</h1>
       <p className="text-lg mb-10">
-        To start, please enter your unlock password
+        To continue, please enter your unlock password
       </p>
       <form onSubmit={onSubmit} className="mb-10">
         <>
@@ -65,10 +64,6 @@ export default function Start() {
           <ConnectButton isConnecting={loading} />
         </>
       </form>
-
-      <Link to="/setup" className=" text-red-500">
-        Forgot password?
-      </Link>
     </>
   );
 }

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -90,6 +90,7 @@ export interface InfoResponse {
   backendType: BackendType;
   setupCompleted: boolean;
   running: boolean;
+  unlocked: boolean;
 }
 
 export interface CreateAppResponse {

--- a/http_service.go
+++ b/http_service.go
@@ -16,9 +16,8 @@ import (
 )
 
 type HttpService struct {
-	svc           *Service
-	api           *API
-	encryptionKey string
+	svc *Service
+	api *API
 }
 
 func NewHttpService(svc *Service) *HttpService {
@@ -105,8 +104,6 @@ func (httpSvc *HttpService) startHandler(c echo.Context) error {
 		})
 	}
 
-	httpSvc.encryptionKey = startRequest.UnlockPassword
-
 	return c.NoContent(http.StatusNoContent)
 }
 
@@ -118,8 +115,10 @@ func (httpSvc *HttpService) unlockHandler(c echo.Context) error {
 		})
 	}
 
-	if unlockRequest.UnlockPassword != httpSvc.encryptionKey {
-		return c.NoContent(http.StatusUnauthorized)
+	if !httpSvc.svc.cfg.CheckUnlockPassword(unlockRequest.UnlockPassword) {
+		return c.JSON(http.StatusUnauthorized, ErrorResponse{
+			Message: "Invalid password",
+		})
 	}
 
 	err := httpSvc.saveSessionCookie(c)

--- a/http_service.go
+++ b/http_service.go
@@ -251,6 +251,10 @@ func (httpSvc *HttpService) setupHandler(c echo.Context) error {
 		})
 	}
 
+	if httpSvc.svc.lnClient != nil && !httpSvc.isUnlocked(c) {
+		return c.NoContent(http.StatusUnauthorized)
+	}
+
 	err := httpSvc.api.Setup(&setupRequest)
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, ErrorResponse{

--- a/http_service.go
+++ b/http_service.go
@@ -57,9 +57,11 @@ func (httpSvc *HttpService) RegisterSharedRoutes(e *echo.Echo) {
 	e.GET("/api/info", httpSvc.infoHandler)
 	e.POST("/api/logout", httpSvc.logoutHandler)
 	e.POST("/api/setup", httpSvc.setupHandler)
-	e.POST("/api/start", httpSvc.startHandler)
-	// TODO: add rate limiter
-	e.POST("/api/unlock", httpSvc.unlockHandler)
+
+	// allow one unlock request per second
+	unlockRateLimiter := middleware.RateLimiter(middleware.NewRateLimiterMemoryStore(1))
+	e.POST("/api/start", httpSvc.startHandler, unlockRateLimiter)
+	e.POST("/api/unlock", httpSvc.unlockHandler, unlockRateLimiter)
 
 	frontend.RegisterHandlers(e)
 }

--- a/models/api/api.go
+++ b/models/api/api.go
@@ -36,6 +36,10 @@ type StartRequest struct {
 	UnlockPassword string `json:"unlockPassword"`
 }
 
+type UnlockRequest struct {
+	UnlockPassword string `json:"unlockPassword"`
+}
+
 type SetupRequest struct {
 	LNBackendType string `json:"backendType"`
 	// Breez fields
@@ -67,4 +71,5 @@ type InfoResponse struct {
 	BackendType    string `json:"backendType"`
 	SetupCompleted bool   `json:"setupCompleted"`
 	Running        bool   `json:"running"`
+	Unlocked       bool   `json:"unlocked"`
 }

--- a/start.go
+++ b/start.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"errors"
+
 	"github.com/nbd-wtf/go-nostr"
 	"github.com/nbd-wtf/go-nostr/nip19"
 )
@@ -78,6 +80,11 @@ func (svc *Service) StartNostr(encryptionKey string) error {
 }
 
 func (svc *Service) StartApp(encryptionKey string) error {
+	if !svc.cfg.CheckUnlockPassword(encryptionKey) {
+		svc.Logger.Errorf("Invalid password")
+		return errors.New("Invalid password")
+	}
+
 	err := svc.launchLNBackend(encryptionKey)
 	if err != nil {
 		svc.Logger.Errorf("Failed to launch LN backend: %v", err)


### PR DESCRIPTION
TODO
- [x] review storing the encryption key for checking in the http service
- [x] is it ok that we only support the http usecase for now? - I think we can rely on standard PC unlock screen for Wails.
- [ ] review cookie structure
- [x] return to previous URL functionality after logging in
- [x] proper password check on startup
- [x] setup page can currently be accessed if the app is running without a password - a malicious user could then change the node backend. I think this should be locked if the app is running 
- [x] prevent brute forcing passwords - currently rate limited at 1 request per second
- [x] review general UX (start/unlock flow)