### PR TITLE
Fix info event to be space separated

### DIFF
--- a/models.go
+++ b/models.go
@@ -26,7 +26,7 @@ const (
 	NIP_47_ERROR_EXPIRED              = "EXPIRED"
 	NIP_47_ERROR_RESTRICTED           = "RESTRICTED"
 	NIP_47_OTHER                      = "OTHER"
-	NIP_47_CAPABILITIES               = "pay_invoice,pay_keysend,get_balance,get_info,make_invoice,lookup_invoice,list_transactions"
+	NIP_47_CAPABILITIES               = "pay_invoice pay_keysend get_balance get_info make_invoice lookup_invoice list_transactions"
 )
 
 const (

--- a/service.go
+++ b/service.go
@@ -263,7 +263,7 @@ func (svc *Service) GetMethods(app *App) []string {
 	})
 	if findPermissionsResult.RowsAffected == 0 {
 		// No permissions created for this app. It can do anything
-		return strings.Split(NIP_47_CAPABILITIES, ",")
+		return strings.Split(NIP_47_CAPABILITIES, " ")
 	}
 	requestMethods := make([]string, 0, len(appPermissions))
 	for _, appPermission := range appPermissions {


### PR DESCRIPTION
The [NIP](https://github.com/nostr-protocol/nips/blob/master/47.md#events) defines that the info event should be space separated, not comma separated.

Not sure if this needs to be fixed anywhere else, this seems like it'll only be fixed for instances without changed permissions