### PR TITLE
Added custom_records to metadata field of list_transactions

### DIFF
--- a/alby.go
+++ b/alby.go
@@ -721,6 +721,19 @@ func albyInvoiceToTransaction(invoice *AlbyInvoice) *Nip47Transaction {
 		settledAt = &settledAtUnix
 	}
 
+	var customRecords = map[string]string{}
+	for key, value := range invoice.CustomRecords {
+		customRecords[key] = value // already base64 encoded
+	}
+
+	var metadata = map[string]interface{}{}
+	if invoice.Metadata != nil {
+		metadata["alby"] = invoice.Metadata
+	}
+	if len(customRecords) != 0 {
+		metadata["custom_records"] = customRecords
+	}
+
 	return &Nip47Transaction{
 		Type:            invoice.Type,
 		Invoice:         invoice.PaymentRequest,
@@ -733,6 +746,6 @@ func albyInvoiceToTransaction(invoice *AlbyInvoice) *Nip47Transaction {
 		CreatedAt:       invoice.CreatedAt.Unix(),
 		ExpiresAt:       expiresAt,
 		SettledAt:       settledAt,
-		Metadata:        invoice.Metadata,
+		Metadata:        metadata,
 	}
 }

--- a/models.go
+++ b/models.go
@@ -149,7 +149,7 @@ type AlbyInvoice struct {
 	CreatedAt time.Time `json:"created_at"`
 	// CreationDate uint64 `json:"creation_date"`
 	Currency string `json:"currency"`
-	// custom_records
+	CustomRecords map[string]string `json:"custom_records,omitempty"`
 	DescriptionHash string     `json:"description_hash"`
 	ExpiresAt       *time.Time `json:"expires_at"`
 	Expiry          uint32     `json:"expiry"`


### PR DESCRIPTION
This PR adds custom records from invoices/payments to the metadata field of the `list_transactions` response. Based on the comments in the code, this seems to be where it was intended to be added, but I can move it to its own field if desired.

This addition would be useful to any application that sends and receives boostagrams as that data is stored in the custom records of each payment/invoice.

The code follows the Alby API convention of base64 encoding the values of each custom record. I moved the existing Alby metadata to an `alby` key in the new metadata structure. I'm not sure what metadata is being returned by the Alby API as all of mine are empty and it's not well documented in the docs: https://guides.getalby.com/developer-guide/v/alby-wallet-api/reference/api-reference/invoices#get-incoming-invoice-history .

If accepted, I wonder if we shouldn't also add a separate param in list_transactions to conditionally request metadata rather than sending it by default to save space. Users would need to request custom_records be returned by adding a `"metadata": ["custom_records"]` parameter or have a list, e.g. `"metadata": ["custom_records", "alby"]`